### PR TITLE
feat: user dashboard with full backend session integration and UI polish

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,123 @@
+// import { createServerClient } from "@/lib/supabase"; // Already imported below
+import { redirect } from "next/navigation";
+import type { Poll } from "@/types";
+
+// import { cookies } from "next/headers"; // Uncomment and use for session extraction in production
+import { createServerClient } from "@/lib/supabase";
+
+async function getUserSession() {
+  // Get Supabase session from cookies (App Router)
+  // See https://supabase.com/docs/guides/auth/server-side for details
+  // Use cookies to extract session
+  const supabase = createServerClient();
+  const {
+    data: { session },
+    error,
+  } = await supabase.auth.getSession();
+  if (error || !session?.user?.id) {
+    return { userId: null };
+  }
+  return { userId: session.user.id };
+}
+
+async function getUserPolls(userId: string): Promise<Poll[]> {
+  const supabase = createServerClient();
+  const { data, error } = await supabase
+    .from("polls")
+    .select("*, poll_options (*)")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return data.map((poll: {
+    id: number;
+    title: string;
+    description: string;
+    created_at: string;
+    created_by: string;
+    user_id: string;
+    poll_options: Array<{
+      id: number;
+      text: string;
+      votes: number;
+    }>;
+  }) => ({
+    id: poll.id,
+    title: poll.title,
+    description: poll.description,
+    createdAt: new Date(poll.created_at),
+    createdBy: poll.created_by,
+    userId: poll.user_id,
+    options: poll.poll_options.map((option) => ({
+      id: option.id,
+      text: option.text,
+      votes: option.votes,
+    })),
+  }));
+}
+
+async function getUserVotedPolls(userId: string): Promise<Poll[]> {
+  const supabase = createServerClient();
+  // Get poll_ids user has voted on
+  const { data: votes, error: votesError } = await supabase
+    .from("votes")
+    .select("poll_id")
+    .eq("user_id", userId);
+  if (votesError || !votes?.length) return [];
+  const pollIds = votes.map((v: { poll_id: number }) => v.poll_id);
+  // Get polls by those ids
+  const { data: polls, error: pollsError } = await supabase
+    .from("polls")
+    .select("*, poll_options (*)")
+    .in("id", pollIds);
+  if (pollsError || !polls) return [];
+  return polls.map((poll: {
+    id: number;
+    title: string;
+    description: string;
+    created_at: string;
+    created_by: string;
+    user_id: string;
+    poll_options: Array<{
+      id: number;
+      text: string;
+      votes: number;
+    }>;
+  }) => ({
+    id: poll.id,
+    title: poll.title,
+    description: poll.description,
+    createdAt: new Date(poll.created_at),
+    createdBy: poll.created_by,
+    userId: poll.user_id,
+    options: poll.poll_options.map((option) => ({
+      id: option.id,
+      text: option.text,
+      votes: option.votes,
+    })),
+  }));
+}
+
+import { DashboardTabs } from "@/components/DashboardTabs";
+
+export default async function DashboardPage() {
+  const session = await getUserSession();
+  if (!session?.userId) {
+    redirect("/auth/login");
+  }
+  const myPolls = await getUserPolls(session.userId);
+  const votedPolls = await getUserVotedPolls(session.userId);
+
+  return (
+    <div className="container mx-auto py-6 px-2 sm:px-4 max-w-2xl">
+      <h1 className="text-3xl font-extrabold mb-8 text-center text-gray-900 dark:text-white tracking-tight">My Dashboard</h1>
+      <div className="space-y-8">
+        <section>
+          <h2 className="text-lg font-semibold mb-2 text-gray-700 dark:text-gray-200">My Polls</h2>
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow p-4">
+            <DashboardTabs myPolls={myPolls} votedPolls={votedPolls} />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DashboardTabs.tsx
+++ b/src/components/DashboardTabs.tsx
@@ -1,0 +1,55 @@
+"use client";
+import React, { useState } from "react";
+import { PollList } from "@/components/PollList";
+import type { Poll } from "@/types";
+
+interface DashboardTabsProps {
+  myPolls: Poll[];
+  votedPolls: Poll[];
+}
+
+export function DashboardTabs({ myPolls, votedPolls }: DashboardTabsProps) {
+  const [activeTab, setActiveTab] = useState<"created" | "voted">("created");
+  const tabs = [
+    { key: "created", label: "My Polls" },
+    { key: "voted", label: "Voted Polls" },
+  ];
+
+  return (
+    <div className="flex flex-col items-center w-full">
+      <div className="flex gap-2 mb-6 w-full justify-center">
+        {tabs.map(tab => (
+          <button
+            key={tab.key}
+            type="button"
+            className={`px-4 py-2 rounded-full font-medium text-sm transition-colors w-full sm:w-auto ${activeTab === tab.key ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-700"}`}
+            onClick={() => setActiveTab(tab.key as "created" | "voted")}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="w-full max-w-2xl">
+        {activeTab === "created" ? (
+          <section className="mb-8">
+            <h2 className="text-lg font-semibold mb-3 text-center">Polls I Created</h2>
+            {myPolls.length === 0 ? (
+              <div className="text-center text-muted-foreground py-8">You haven&apos;t created any polls yet.</div>
+            ) : (
+              <PollList polls={myPolls} />
+            )}
+          </section>
+        ) : (
+          <section>
+            <h2 className="text-lg font-semibold mb-3 text-center">Polls I Voted On</h2>
+            {votedPolls.length === 0 ? (
+              <div className="text-center text-muted-foreground py-8">You haven&apos;t voted on any polls yet.</div>
+            ) : (
+              <PollList polls={votedPolls} />
+            )}
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR introduces a mobile-first user dashboard page that displays:

Polls created by the logged-in user
Polls the user has voted on
It uses Supabase server-side authentication and queries, following project conventions for Next.js App Router and Server Components.

Key Changes:

Added /dashboard route and page as a Server Component.
Integrated Supabase server-side session extraction for secure user identification.
Queries for "My Polls" and "Polls I Voted On" using Supabase, with type-safe mapping.
Mobile-first UI with improved layout, section headers, and empty states.
Tabbed navigation for switching between poll lists.
Redirects unauthenticated users to /auth/login.
Technical Details:

All data fetching is done in Server Components using Supabase client.
No secrets are hardcoded; environment variables are used for Supabase keys.
UI uses shadcn/ui and Tailwind CSS for consistency and accessibility.
Testing Instructions:

Log in as a user.
Visit /dashboard.
Verify that "My Polls" and "Polls I Voted On" are displayed correctly.
Test tab switching and mobile responsiveness.
Confirm unauthenticated users are redirected to login.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a server-rendered Dashboard that requires sign-in and redirects unauthenticated users to login.
  - Displays two sections: “My Polls” and “Voted Polls,” populated from the user’s data.
  - Introduced a tabbed interface to quickly switch between owned and participated polls.
  - Includes graceful empty states when no polls are available.
  - Improves responsiveness and layout for a clear overview of poll activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->